### PR TITLE
feat: telegram delivery channel for newsletters

### DIFF
--- a/migrations/016_telegram_delivery.sql
+++ b/migrations/016_telegram_delivery.sql
@@ -1,0 +1,28 @@
+-- Telegram delivery for newsletters.
+--
+-- Per-user chat_id (not per-subscription): users link once, all subscriptions
+-- route to that chat. If a user unlinks, TG subscriptions fall back to email
+-- silently unless delivery_channel is explicitly 'telegram' only.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS telegram_chat_id TEXT,
+  ADD COLUMN IF NOT EXISTS telegram_username TEXT,
+  ADD COLUMN IF NOT EXISTS telegram_linked_at TIMESTAMPTZ;
+
+-- Per-subscription delivery channel. 'email' keeps existing behavior.
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS delivery_channel TEXT NOT NULL DEFAULT 'email'
+    CHECK (delivery_channel IN ('email', 'telegram'));
+
+-- One-time link codes: user generates a code in-app, DMs the bot with /start <code>,
+-- webhook verifies and writes chat_id back to users table.
+CREATE TABLE IF NOT EXISTS telegram_link_codes (
+  code TEXT PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_telegram_link_codes_user ON telegram_link_codes (user_id);
+CREATE INDEX IF NOT EXISTS idx_telegram_link_codes_expires ON telegram_link_codes (expires_at) WHERE consumed_at IS NULL;

--- a/scripts/setup-telegram-webhook.ts
+++ b/scripts/setup-telegram-webhook.ts
@@ -1,0 +1,39 @@
+// Register the Telegram bot webhook. Run once after deploy:
+//
+//   npx tsx scripts/setup-telegram-webhook.ts
+//
+// Requires env: TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_URL (e.g. https://www.myjunto.xyz/api/telegram/webhook)
+// Optional: TELEGRAM_WEBHOOK_SECRET — if set, TG will echo it in the x-telegram-bot-api-secret-token header
+// so the webhook route can verify authenticity.
+
+async function main() {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const url = process.env.TELEGRAM_WEBHOOK_URL;
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  if (!token) throw new Error('TELEGRAM_BOT_TOKEN not set');
+  if (!url) throw new Error('TELEGRAM_WEBHOOK_URL not set (e.g. https://www.myjunto.xyz/api/telegram/webhook)');
+
+  const body: Record<string, unknown> = {
+    url,
+    allowed_updates: ['message'],
+    drop_pending_updates: true,
+  };
+  if (secret) body.secret_token = secret;
+
+  const res = await fetch(`https://api.telegram.org/bot${token}/setWebhook`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  console.log('setWebhook:', data);
+
+  const info = await fetch(`https://api.telegram.org/bot${token}/getWebhookInfo`).then((r) => r.json());
+  console.log('getWebhookInfo:', info);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/cron/generate-newsletters/route.ts
+++ b/src/app/api/cron/generate-newsletters/route.ts
@@ -6,6 +6,7 @@ import { storeRun } from '@/lib/db/newsletter-runs';
 import { recordBulkDeliveries } from '@/lib/db/newsletter-deliveries';
 import { generateNewsletterV2 } from '@/lib/synthesis/generator-v2';
 import { sendNewsletter } from '@/lib/email/sender';
+import { sendTelegramNewsletter } from '@/lib/telegram/client';
 import { chargeOwner, chargeSubscriber } from '@/lib/db/credits';
 import { calculateOwnerCreditCost, calculateSubscriberCreditCost } from '@/lib/pricing';
 import { getPromptTemplateById } from '@/lib/db/prompt-templates';
@@ -139,7 +140,8 @@ export async function GET(req: NextRequest) {
 
         const subscriberCost = calculateSubscriberCreditCost();
         const deliveredEmails: string[] = [];
-        const deliveredUserIds: string[] = [];
+        const deliveredEmailUserIds: string[] = [];
+        const telegramTargets: { chatId: string; userId: string }[] = [];
 
         for (const sub of subscribers) {
           const charged = await chargeSubscriber(
@@ -155,42 +157,80 @@ export async function GET(req: NextRequest) {
             continue;
           }
 
-          const email = sub.delivery_email || sub.email;
-          if (email) {
-            deliveredEmails.push(email);
-            deliveredUserIds.push(sub.user_id);
+          if (sub.delivery_channel === 'telegram' && sub.telegram_chat_id) {
+            telegramTargets.push({ chatId: sub.telegram_chat_id, userId: sub.user_id });
+          } else {
+            const email = sub.delivery_email || sub.email;
+            if (email) {
+              deliveredEmails.push(email);
+              deliveredEmailUserIds.push(sub.user_id);
+            }
           }
         }
 
-        if (deliveredEmails.length === 0) {
+        const totalTargets = deliveredEmails.length + telegramTargets.length;
+        if (totalTargets === 0) {
           console.log(`[generate] No payable subscribers for ${newsletter.name}`);
           results[newsletter.name] = { status: 'generated', subscribers: 0 };
           continue;
         }
 
-        console.log(`[generate] Sending to ${deliveredEmails.length} subscriber(s)...`);
+        console.log(
+          `[generate] Sending ${newsletter.name} to ${deliveredEmails.length} email, ${telegramTargets.length} telegram...`,
+        );
 
-        try {
-          await sendNewsletter({
-            to: deliveredEmails,
-            subject: result.subject,
-            content: result.content,
-            newsletterId: newsletter.id,
-            newsletterName: newsletter.name,
-          });
+        const deliveryErrors: string[] = [];
 
-          await recordBulkDeliveries(run.id, deliveredUserIds, 'email');
-
-          console.log(`[generate] Delivered ${newsletter.name} to ${deliveredEmails.length} subscribers`);
-          results[newsletter.name] = { status: 'delivered', subscribers: deliveredEmails.length };
-        } catch (emailError) {
-          console.error(`[generate] Email send failed for ${newsletter.name}:`, emailError);
-          results[newsletter.name] = {
-            status: 'generated_not_delivered',
-            subscribers: deliveredEmails.length,
-            error: emailError instanceof Error ? emailError.message : 'Email send failed',
-          };
+        // Email fanout
+        if (deliveredEmails.length > 0) {
+          try {
+            await sendNewsletter({
+              to: deliveredEmails,
+              subject: result.subject,
+              content: result.content,
+              newsletterId: newsletter.id,
+              newsletterName: newsletter.name,
+            });
+            await recordBulkDeliveries(run.id, deliveredEmailUserIds, 'email');
+          } catch (emailError) {
+            const msg = emailError instanceof Error ? emailError.message : 'Email send failed';
+            console.error(`[generate] Email send failed for ${newsletter.name}:`, emailError);
+            deliveryErrors.push(`email: ${msg}`);
+          }
         }
+
+        // Telegram fanout — one message per chat (TG is per-recipient, no batching)
+        const successfulTgUserIds: string[] = [];
+        for (const target of telegramTargets) {
+          try {
+            await sendTelegramNewsletter({
+              chatId: target.chatId,
+              subject: result.subject,
+              contentMarkdown: result.content,
+              newsletterId: newsletter.id,
+            });
+            successfulTgUserIds.push(target.userId);
+          } catch (tgError) {
+            const msg = tgError instanceof Error ? tgError.message : 'Telegram send failed';
+            console.error(`[generate] Telegram send failed for ${newsletter.name} chat ${target.chatId}:`, tgError);
+            deliveryErrors.push(`telegram ${target.chatId}: ${msg}`);
+          }
+        }
+        if (successfulTgUserIds.length > 0) {
+          await recordBulkDeliveries(run.id, successfulTgUserIds, 'telegram');
+        }
+
+        const delivered = deliveredEmailUserIds.length + successfulTgUserIds.length;
+        console.log(`[generate] Delivered ${newsletter.name} to ${delivered}/${totalTargets}`);
+
+        results[newsletter.name] =
+          deliveryErrors.length > 0
+            ? {
+                status: delivered > 0 ? 'partial_delivered' : 'generated_not_delivered',
+                subscribers: delivered,
+                error: deliveryErrors.join('; '),
+              }
+            : { status: 'delivered', subscribers: delivered };
       } catch (error) {
         console.error(`[generate] Error processing ${newsletter.name}:`, error);
         results[newsletter.name] = {

--- a/src/app/api/telegram/link/route.ts
+++ b/src/app/api/telegram/link/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { getSupabase } from '@/lib/db/client';
+import { createLinkCode, getUserTelegramChatId, unlinkTelegram } from '@/lib/telegram/link';
+
+// Session → user.id lookup. Mirrors the pattern in /api/user/settings.
+type SessionUserExtra = { twitterId?: string; twitterHandle?: string; email?: string | null };
+
+async function resolveUserId(session: { user?: SessionUserExtra } | null): Promise<string | null> {
+  if (!session?.user) return null;
+  const supabase = getSupabase();
+  const { twitterId, twitterHandle, email } = session.user;
+
+  if (twitterId) {
+    const { data } = await supabase.from('users').select('id').eq('twitter_id', twitterId).maybeSingle();
+    if (data?.id) return data.id;
+  }
+  if (twitterHandle) {
+    const { data } = await supabase.from('users').select('id').eq('twitter_handle', twitterHandle).maybeSingle();
+    if (data?.id) return data.id;
+  }
+  if (email) {
+    const { data } = await supabase.from('users').select('id').eq('email', email).maybeSingle();
+    if (data?.id) return data.id;
+  }
+  return null;
+}
+
+// POST — generate a one-time code. Returns the code + a t.me deeplink that
+// pre-fills /start <code> when the user taps it.
+export async function POST() {
+  const session = (await getServerSession(authOptions)) as { user?: SessionUserExtra } | null;
+  const userId = await resolveUserId(session);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const botUsername = process.env.TELEGRAM_BOT_USERNAME;
+  if (!botUsername) {
+    return NextResponse.json({ error: 'Bot username not configured' }, { status: 500 });
+  }
+
+  const { code, expiresAt } = await createLinkCode(userId);
+  const clean = botUsername.replace('@', '');
+  const deeplink = `https://t.me/${clean}?start=${code}`;
+
+  return NextResponse.json({ code, deeplink, expiresAt });
+}
+
+// GET — current link status for the signed-in user
+export async function GET() {
+  const session = (await getServerSession(authOptions)) as { user?: SessionUserExtra } | null;
+  const userId = await resolveUserId(session);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const chatId = await getUserTelegramChatId(userId);
+  return NextResponse.json({ linked: !!chatId });
+}
+
+// DELETE — unlink
+export async function DELETE() {
+  const session = (await getServerSession(authOptions)) as { user?: SessionUserExtra } | null;
+  const userId = await resolveUserId(session);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  await unlinkTelegram(userId);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { consumeLinkCode } from '@/lib/telegram/link';
+import { sendTelegramMessage } from '@/lib/telegram/client';
+
+// Telegram webhook. Configured via setWebhook during deploy (see
+// scripts/setup-telegram-webhook.ts). Handles /start <code> for account linking.
+//
+// Telegram optionally signs requests via the secret_token header — we verify
+// against TELEGRAM_WEBHOOK_SECRET if set.
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (secret) {
+    const provided = req.headers.get('x-telegram-bot-api-secret-token');
+    if (provided !== secret) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  let update: TelegramUpdate;
+  try {
+    update = (await req.json()) as TelegramUpdate;
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+
+  const msg = update.message;
+  if (!msg?.text || !msg.chat?.id) return NextResponse.json({ ok: true });
+
+  const text = msg.text.trim();
+  const chatId = msg.chat.id;
+  const username = msg.from?.username;
+
+  // /start <code> — account linking
+  const startMatch = /^\/start(?:@\w+)?\s+([A-Z0-9]{4,16})\s*$/i.exec(text);
+  if (startMatch) {
+    const code = startMatch[1];
+    const result = await consumeLinkCode({ code, chatId, username });
+    if (result.success) {
+      await sendTelegramMessage(
+        chatId,
+        `✅ <b>Linked.</b>\n\nYour Junto account is now connected. Subscribe to a newsletter and choose Telegram delivery to receive it here.`,
+      );
+    } else {
+      const msgByReason: Record<string, string> = {
+        not_found: '❌ That code is invalid. Generate a new one from your Junto dashboard.',
+        expired: '⏳ That code has expired. Generate a fresh one from your Junto dashboard.',
+        already_used: '⚠️ That code has already been used.',
+        lookup_error: '⚠️ Something went wrong on our end. Try again in a minute.',
+        update_user_failed: '⚠️ Couldn\'t link your account. Try again or contact support.',
+      };
+      await sendTelegramMessage(chatId, msgByReason[result.reason] ?? msgByReason.lookup_error);
+    }
+    return NextResponse.json({ ok: true });
+  }
+
+  // Bare /start with no code — onboarding hint
+  if (/^\/start(?:@\w+)?\s*$/.test(text)) {
+    await sendTelegramMessage(
+      chatId,
+      `👋 <b>Junto</b>\n\nTo link your account, open <a href="https://www.myjunto.xyz/settings">your Junto settings</a>, click <i>Link Telegram</i>, and tap the generated link.`,
+    );
+    return NextResponse.json({ ok: true });
+  }
+
+  // Everything else — silent ignore (phase 1 is delivery-only, not conversational)
+  return NextResponse.json({ ok: true });
+}
+
+// Minimal type for the fields we use from the TG update payload
+interface TelegramUpdate {
+  message?: {
+    text?: string;
+    chat?: { id: number };
+    from?: { username?: string };
+  };
+}

--- a/src/app/api/v2/newsletters/[id]/subscribe/route.ts
+++ b/src/app/api/v2/newsletters/[id]/subscribe/route.ts
@@ -69,6 +69,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     let deliveryEmail = body.delivery_email;
     const sendWindows: string[] = body.receive_windows || body.send_windows || ['morning'];
     const receiveDays: string[] = body.receive_days || ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const deliveryChannel: 'email' | 'telegram' = body.delivery_channel === 'telegram' ? 'telegram' : 'email';
 
     // Validate send_windows values
     const validWindows = ['morning', 'midday', 'evening', 'night'];
@@ -80,16 +81,26 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       );
     }
 
-    // Fall back to account email if no delivery_email provided
-    if (!deliveryEmail) {
-      deliveryEmail = await getUserEmail(userId);
-    }
-
-    if (!deliveryEmail) {
-      return NextResponse.json(
-        { error: 'Delivery email required. Set an account email or provide delivery_email.' },
-        { status: 400 },
-      );
+    // Telegram channel requires the user to have linked their account first
+    if (deliveryChannel === 'telegram') {
+      const { data: userRow } = await supabase.from('users').select('telegram_chat_id').eq('id', userId).single();
+      if (!userRow?.telegram_chat_id) {
+        return NextResponse.json(
+          { error: 'Telegram not linked. Link your account in settings first.', code: 'telegram_not_linked' },
+          { status: 400 },
+        );
+      }
+    } else {
+      // Email channel: fall back to account email if no delivery_email provided
+      if (!deliveryEmail) {
+        deliveryEmail = await getUserEmail(userId);
+      }
+      if (!deliveryEmail) {
+        return NextResponse.json(
+          { error: 'Delivery email required. Set an account email or provide delivery_email.' },
+          { status: 400 },
+        );
+      }
     }
 
     // Validate receive_days
@@ -102,7 +113,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       );
     }
 
-    const subscription = await subscribe(userId, id, deliveryEmail, sendWindows, receiveDays);
+    const subscription = await subscribe(userId, id, deliveryEmail, sendWindows, receiveDays, deliveryChannel);
     return NextResponse.json({ subscription, subscribed: true });
   } catch (error) {
     console.error('[POST /subscribe]', error);

--- a/src/app/newsletter/[id]/page.tsx
+++ b/src/app/newsletter/[id]/page.tsx
@@ -55,6 +55,10 @@ export default function NewsletterDetailPage() {
   const [subEmail, setSubEmail] = useState('');
   const [subWindows, setSubWindows] = useState<string[]>(['morning']);
   const [subDays, setSubDays] = useState<string[]>(['mon', 'tue', 'wed', 'thu', 'fri']);
+  const [subDeliveryChannel, setSubDeliveryChannel] = useState<'email' | 'telegram'>('email');
+  const [tgLinked, setTgLinked] = useState<boolean | null>(null);
+  const [tgDeeplink, setTgDeeplink] = useState<string | null>(null);
+  const [tgLinkingPoll, setTgLinkingPoll] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -103,8 +107,43 @@ export default function NewsletterDetailPage() {
       fetch('/api/v2/account').then(r => r.json()).then(data => {
         if (data.email) setSubEmail(data.email);
       }).catch(() => {});
+      fetch('/api/telegram/link').then(r => r.json()).then(data => {
+        setTgLinked(!!data.linked);
+      }).catch(() => setTgLinked(false));
     }
   }, [session]);
+
+  async function startTelegramLink() {
+    const res = await fetch('/api/telegram/link', { method: 'POST' });
+    if (!res.ok) return;
+    const data = await res.json();
+    setTgDeeplink(data.deeplink);
+    window.open(data.deeplink, '_blank', 'noopener,noreferrer');
+
+    // Poll link status every 2s for up to 2 min — user DMs the bot, webhook
+    // captures chat_id, we flip tgLinked to true once it lands.
+    setTgLinkingPoll(true);
+    const start = Date.now();
+    const interval = setInterval(async () => {
+      if (Date.now() - start > 120_000) {
+        clearInterval(interval);
+        setTgLinkingPoll(false);
+        return;
+      }
+      try {
+        const r = await fetch('/api/telegram/link');
+        if (r.ok) {
+          const d = await r.json();
+          if (d.linked) {
+            setTgLinked(true);
+            setTgLinkingPoll(false);
+            setTgDeeplink(null);
+            clearInterval(interval);
+          }
+        }
+      } catch {}
+    }, 2000);
+  }
 
   async function toggleSubscription() {
     if (!session?.user) {
@@ -136,9 +175,10 @@ export default function NewsletterDetailPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          delivery_email: subEmail,
+          delivery_email: subDeliveryChannel === 'email' ? subEmail : undefined,
           receive_windows: subWindows,
           receive_days: subDays,
+          delivery_channel: subDeliveryChannel,
         }),
       });
       if (res.ok) {
@@ -397,17 +437,76 @@ export default function NewsletterDetailPage() {
               <p className="text-sm text-slate-400 mt-1">2 credits per delivery</p>
             </div>
 
-            {/* Delivery email */}
+            {/* Delivery channel */}
             <div>
-              <label className="block text-xs text-slate-400 font-medium mb-2">Delivery email</label>
-              <input
-                type="email"
-                value={subEmail}
-                onChange={(e) => setSubEmail(e.target.value)}
-                placeholder="you@example.com"
-                className="w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 rounded-xl text-sm text-white placeholder-slate-500 focus:outline-none focus:border-blue-500"
-              />
+              <label className="block text-xs text-slate-400 font-medium mb-2">Deliver via</label>
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  { key: 'email', label: 'Email' },
+                  { key: 'telegram', label: 'Telegram' },
+                ].map((opt) => (
+                  <button
+                    key={opt.key}
+                    onClick={() => setSubDeliveryChannel(opt.key as 'email' | 'telegram')}
+                    className={`px-3 py-2 rounded-lg text-sm font-medium transition ${
+                      subDeliveryChannel === opt.key
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-slate-700/50 text-slate-400 hover:bg-slate-700'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
             </div>
+
+            {/* Email field — shown when email channel is selected */}
+            {subDeliveryChannel === 'email' && (
+              <div>
+                <label className="block text-xs text-slate-400 font-medium mb-2">Delivery email</label>
+                <input
+                  type="email"
+                  value={subEmail}
+                  onChange={(e) => setSubEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  className="w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 rounded-xl text-sm text-white placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                />
+              </div>
+            )}
+
+            {/* Telegram linking — shown when telegram channel is selected */}
+            {subDeliveryChannel === 'telegram' && (
+              <div>
+                <label className="block text-xs text-slate-400 font-medium mb-2">Telegram</label>
+                {tgLinked ? (
+                  <div className="px-3 py-2.5 bg-emerald-500/10 border border-emerald-500/30 rounded-xl text-sm text-emerald-300">
+                    ✓ Connected — newsletters will arrive as DMs
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <button
+                      onClick={startTelegramLink}
+                      className="w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 hover:border-blue-500 rounded-xl text-sm text-white transition"
+                    >
+                      {tgLinkingPoll ? 'Waiting for you to message the bot…' : 'Link Telegram'}
+                    </button>
+                    {tgDeeplink && (
+                      <a
+                        href={tgDeeplink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block text-xs text-blue-400 hover:text-blue-300 text-center"
+                      >
+                        Open Telegram →
+                      </a>
+                    )}
+                    <p className="text-xs text-slate-500">
+                      Opens Telegram and starts a chat with our bot. One tap to link.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Send windows */}
             <div>
@@ -475,7 +574,13 @@ export default function NewsletterDetailPage() {
               </button>
               <button
                 onClick={handleSubscribe}
-                disabled={subscribing || !subEmail || subWindows.length === 0 || subDays.length === 0}
+                disabled={
+                  subscribing ||
+                  subWindows.length === 0 ||
+                  subDays.length === 0 ||
+                  (subDeliveryChannel === 'email' && !subEmail) ||
+                  (subDeliveryChannel === 'telegram' && !tgLinked)
+                }
                 className="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-xl text-sm font-medium transition"
               >
                 {subscribing ? 'Subscribing...' : 'Subscribe'}

--- a/src/lib/db/subscriptions.ts
+++ b/src/lib/db/subscriptions.ts
@@ -9,6 +9,7 @@ export async function subscribe(
   deliveryEmail?: string,
   sendWindows?: string[],
   receiveDays?: string[],
+  deliveryChannel?: 'email' | 'telegram',
 ): Promise<Subscription> {
   const row: Record<string, any> = { user_id: userId, newsletter_id: newsletterId, is_active: true };
   if (deliveryEmail) row.delivery_email = deliveryEmail;
@@ -17,6 +18,7 @@ export async function subscribe(
     row.receive_windows = sendWindows;
   }
   if (receiveDays) row.receive_days = receiveDays;
+  if (deliveryChannel) row.delivery_channel = deliveryChannel;
 
   const { data, error } = await supabase()
     .from('subscriptions')
@@ -65,16 +67,19 @@ export async function getNewsletterSubscribers(newsletterId: string): Promise<{
   send_windows: string[];
   receive_windows: string[];
   receive_days: string[];
+  delivery_channel: 'email' | 'telegram';
+  telegram_chat_id: string | null;
 }[]> {
   const { data, error } = await supabase()
     .from('subscriptions')
-    .select('user_id, delivery_email, send_windows, receive_windows, receive_days, users(email)')
+    .select(
+      'user_id, delivery_email, send_windows, receive_windows, receive_days, delivery_channel, users(email, telegram_chat_id)',
+    )
     .eq('newsletter_id', newsletterId)
     .eq('is_active', true);
 
   if (error) throw error;
   return (data || [])
-    .filter((row: any) => row.delivery_email || row.users?.email)
     .map((row: any) => ({
       user_id: row.user_id,
       email: row.users?.email || '',
@@ -82,7 +87,14 @@ export async function getNewsletterSubscribers(newsletterId: string): Promise<{
       send_windows: row.send_windows || ['morning'],
       receive_windows: row.receive_windows || row.send_windows || ['morning'],
       receive_days: row.receive_days || ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-    }));
+      delivery_channel: (row.delivery_channel || 'email') as 'email' | 'telegram',
+      telegram_chat_id: row.users?.telegram_chat_id || null,
+    }))
+    // Keep any subscriber with a valid route: email address OR linked telegram chat
+    .filter((row: any) => {
+      if (row.delivery_channel === 'telegram') return !!row.telegram_chat_id;
+      return !!(row.delivery_email || row.email);
+    });
 }
 
 export async function isSubscribed(userId: string, newsletterId: string): Promise<boolean> {

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -1,0 +1,134 @@
+// Telegram Bot API client. Uses `fetch` directly — no SDK dependency.
+// https://core.telegram.org/bots/api
+
+const TG_API = 'https://api.telegram.org';
+
+function getToken(): string {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) throw new Error('TELEGRAM_BOT_TOKEN not configured');
+  return token;
+}
+
+interface TgResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+  error_code?: number;
+}
+
+async function tgCall<T>(method: string, body: Record<string, unknown>): Promise<T> {
+  const token = getToken();
+  const res = await fetch(`${TG_API}/bot${token}/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json()) as TgResponse<T>;
+  if (!data.ok) {
+    throw new Error(`Telegram ${method} failed: ${data.error_code} ${data.description}`);
+  }
+  return data.result as T;
+}
+
+interface TgMessage {
+  message_id: number;
+  chat: { id: number };
+}
+
+// Single message send. Content must be pre-escaped HTML (use `markdownToTelegramHtml`).
+export async function sendTelegramMessage(
+  chatId: string | number,
+  html: string,
+  opts: { disablePreview?: boolean } = {},
+): Promise<TgMessage> {
+  return tgCall<TgMessage>('sendMessage', {
+    chat_id: chatId,
+    text: html,
+    parse_mode: 'HTML',
+    disable_web_page_preview: opts.disablePreview ?? true,
+  });
+}
+
+// Newsletter delivery. Splits long content across multiple messages (TG caps at 4096 chars).
+// First message gets the subject as a bold header.
+export async function sendTelegramNewsletter(params: {
+  chatId: string | number;
+  subject: string;
+  contentMarkdown: string;
+  newsletterId?: string;
+}): Promise<{ messageIds: number[] }> {
+  const { chatId, subject, contentMarkdown, newsletterId } = params;
+  const body = markdownToTelegramHtml(contentMarkdown);
+  const header = `<b>${escapeHtml(subject)}</b>\n\n`;
+  const footer = newsletterId
+    ? `\n\n<a href="https://www.myjunto.xyz/newsletter/${newsletterId}">View on Junto</a>`
+    : '';
+
+  const chunks = splitForTelegram(header + body + footer, 4000);
+  const messageIds: number[] = [];
+  for (const chunk of chunks) {
+    const msg = await sendTelegramMessage(chatId, chunk);
+    messageIds.push(msg.message_id);
+  }
+  return { messageIds };
+}
+
+// Split HTML-ish content into <=limit-char chunks, preferring newline breaks.
+// Naive: HTML tags may split across chunks. Good enough for our newsletter content
+// which uses simple inline tags (b, i, a) — unclosed tags render as text but don't
+// corrupt the message.
+export function splitForTelegram(text: string, limit = 4000): string[] {
+  if (text.length <= limit) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    const slice = remaining.slice(0, limit);
+    const lastNewline = slice.lastIndexOf('\n\n');
+    const breakAt = lastNewline > limit / 2 ? lastNewline : slice.lastIndexOf('\n');
+    const cut = breakAt > 0 ? breakAt : limit;
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut).replace(/^\n+/, '');
+  }
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Convert our newsletter markdown to Telegram-supported HTML.
+// TG supported tags: b, strong, i, em, u, ins, s, strike, del, code, pre, a.
+// No headings, lists, blockquotes — we approximate with bold + bullet chars.
+export function markdownToTelegramHtml(md: string): string {
+  // Escape HTML first so real content doesn't collide with our tag insertions
+  let out = escapeHtml(md);
+
+  // Horizontal rules → blank line
+  out = out.replace(/^---+$/gm, '');
+
+  // Headings → bold, preserve size via emoji-ish weight. TG doesn't support h tags.
+  out = out.replace(/^####\s+(.+)$/gm, '<b>$1</b>');
+  out = out.replace(/^###\s+(.+)$/gm, '<b>$1</b>');
+  out = out.replace(/^##\s+(.+)$/gm, '<b>$1</b>');
+  out = out.replace(/^#\s+(.+)$/gm, '<b>$1</b>');
+
+  // Bold + italic combos before single markers
+  out = out.replace(/\*\*\*(.+?)\*\*\*/g, '<b><i>$1</i></b>');
+  out = out.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+  out = out.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<i>$1</i>');
+
+  // Links [text](url)
+  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+  // Bullets: - item → • item
+  out = out.replace(/^-\s+/gm, '• ');
+
+  // Blockquotes: > text → indented with bar char
+  out = out.replace(/^&gt;\s+(.+)$/gm, '▍ <i>$1</i>');
+
+  // Collapse 3+ consecutive newlines to 2 (TG doesn't need email-style breaks)
+  out = out.replace(/\n{3,}/g, '\n\n');
+
+  return out.trim();
+}

--- a/src/lib/telegram/link.ts
+++ b/src/lib/telegram/link.ts
@@ -1,0 +1,89 @@
+import { getSupabase } from '@/lib/db/client';
+import { randomBytes } from 'crypto';
+
+const CODE_TTL_MS = 10 * 60 * 1000; // 10 min
+
+// 8-char URL-safe code (base32-ish, ambiguous chars removed)
+function generateCode(): string {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  const bytes = randomBytes(8);
+  let out = '';
+  for (let i = 0; i < 8; i++) out += alphabet[bytes[i] % alphabet.length];
+  return out;
+}
+
+export async function createLinkCode(userId: string): Promise<{ code: string; expiresAt: string }> {
+  const supabase = getSupabase();
+  const code = generateCode();
+  const expiresAt = new Date(Date.now() + CODE_TTL_MS).toISOString();
+
+  const { error } = await supabase.from('telegram_link_codes').insert({
+    code,
+    user_id: userId,
+    expires_at: expiresAt,
+  });
+
+  if (error) throw new Error(`Failed to create link code: ${error.message}`);
+  return { code, expiresAt };
+}
+
+// Called from the Telegram webhook when a user sends /start <code>. Binds
+// the chat_id to the user, marks the code consumed.
+export async function consumeLinkCode(params: {
+  code: string;
+  chatId: number;
+  username?: string;
+}): Promise<{ success: true; userId: string } | { success: false; reason: string }> {
+  const supabase = getSupabase();
+
+  const { data: row, error } = await supabase
+    .from('telegram_link_codes')
+    .select('user_id, expires_at, consumed_at')
+    .eq('code', params.code.toUpperCase())
+    .maybeSingle();
+
+  if (error) return { success: false, reason: 'lookup_error' };
+  if (!row) return { success: false, reason: 'not_found' };
+  if (row.consumed_at) return { success: false, reason: 'already_used' };
+  if (new Date(row.expires_at).getTime() < Date.now()) return { success: false, reason: 'expired' };
+
+  const { error: updateUserErr } = await supabase
+    .from('users')
+    .update({
+      telegram_chat_id: String(params.chatId),
+      telegram_username: params.username ?? null,
+      telegram_linked_at: new Date().toISOString(),
+    })
+    .eq('id', row.user_id);
+
+  if (updateUserErr) return { success: false, reason: 'update_user_failed' };
+
+  await supabase
+    .from('telegram_link_codes')
+    .update({ consumed_at: new Date().toISOString() })
+    .eq('code', params.code.toUpperCase());
+
+  return { success: true, userId: row.user_id };
+}
+
+export async function getUserTelegramChatId(userId: string): Promise<string | null> {
+  const supabase = getSupabase();
+  const { data } = await supabase
+    .from('users')
+    .select('telegram_chat_id')
+    .eq('id', userId)
+    .maybeSingle();
+  return data?.telegram_chat_id ?? null;
+}
+
+export async function unlinkTelegram(userId: string): Promise<void> {
+  const supabase = getSupabase();
+  await supabase
+    .from('users')
+    .update({
+      telegram_chat_id: null,
+      telegram_username: null,
+      telegram_linked_at: null,
+    })
+    .eq('id', userId);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -168,6 +168,11 @@ export interface Subscription {
   user_id: string;
   newsletter_id: string;
   is_active: boolean;
+  delivery_email?: string | null;
+  delivery_channel?: 'email' | 'telegram';
+  send_windows?: string[];
+  receive_windows?: string[];
+  receive_days?: string[];
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Adds Telegram as a per-subscription delivery channel alongside email. Same content, same cadence, same synthesis pipeline — fork at the final send step. This is phase 1 of the broader "choose your delivery format" plan; change-detection / insight alerts deferred until we see how plain TG delivery feels in use.

## How it works

**Schema** (migration 016):
- `users`: `telegram_chat_id`, `telegram_username`, `telegram_linked_at`
- `subscriptions`: `delivery_channel` enum (`email` | `telegram`, default `email`)
- `telegram_link_codes`: 10-min one-time codes for account linking

**Link flow**:
1. User clicks "Link Telegram" in subscribe modal → `POST /api/telegram/link` generates an 8-char code + `t.me` deeplink
2. Tapping the deeplink opens Telegram with `/start <code>` pre-filled
3. Bot webhook at `/api/telegram/webhook` consumes the code, writes `chat_id` back to the user, bot replies to confirm
4. Modal polls `/api/telegram/link` every 2s to flip "Link" button → "✓ Connected"

**Delivery**:
- `generate-newsletters` splits subscribers into email + telegram buckets
- Email path unchanged (Resend batch)
- Telegram path sends per-chat via `sendTelegramNewsletter` (markdown → TG HTML, 4096-char chunking, links to view on web)
- Per-subscriber failures logged but don't fail the whole run
- `recordBulkDeliveries` tags `delivery_method` as `email` or `telegram` for reporting

## Required env vars (Vercel)

Need to be set before this works in production:

- `TELEGRAM_BOT_TOKEN` — already added
- `TELEGRAM_BOT_USERNAME` — bot handle without the `@` (e.g. `junto_bot`)
- `TELEGRAM_WEBHOOK_SECRET` — optional but strongly recommended; webhook route rejects requests without matching header

## One-time setup after deploy

Register the webhook with Telegram (so bot messages route to our endpoint):

```bash
TELEGRAM_WEBHOOK_URL=https://www.myjunto.xyz/api/telegram/webhook \
  npx tsx scripts/setup-telegram-webhook.ts
```

## Test plan

- [ ] Merge + deploy; confirm env vars set in Vercel
- [ ] Run `scripts/setup-telegram-webhook.ts` — verify `getWebhookInfo` shows the URL
- [ ] DM the bot `/start` — should respond with onboarding hint
- [ ] Log into junto.xyz, open a newsletter's subscribe modal, flip to Telegram
- [ ] Click "Link Telegram" → TG opens → tap send → bot confirms → modal flips to "✓ Connected"
- [ ] Finish subscribe with TG channel selected
- [ ] Manually trigger `/api/cron/generate-newsletters` → TG DM arrives with the newsletter
- [ ] Verify `newsletter_deliveries` has row with `delivery_method = 'telegram'`
- [ ] Test email + TG subscribers on same newsletter → both receive correctly

## Not in this PR (deferred)

- Change-detection / insight alerts (original idea pipeline concept — revisit based on how TG delivery feels)
- Conversational bot / RAG over summaries (phase 2)
- Discord / SMS channels (extend enum + add per-channel send helpers)
- Settings page link/unlink UI (currently linkable only from subscribe modal; manual DB unlink works for now)