### PR TITLE
fix: show telegram link code for manual DM fallback

### DIFF
--- a/src/app/api/telegram/link/route.ts
+++ b/src/app/api/telegram/link/route.ts
@@ -43,7 +43,7 @@ export async function POST() {
   const clean = botUsername.replace('@', '');
   const deeplink = `https://t.me/${clean}?start=${code}`;
 
-  return NextResponse.json({ code, deeplink, expiresAt });
+  return NextResponse.json({ code, deeplink, expiresAt, botUsername: clean });
 }
 
 // GET — current link status for the signed-in user

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest) {
   if (/^\/start(?:@\w+)?\s*$/.test(text)) {
     await sendTelegramMessage(
       chatId,
-      `👋 <b>Junto</b>\n\nTo link your account, open <a href="https://www.myjunto.xyz/settings">your Junto settings</a>, click <i>Link Telegram</i>, and tap the generated link.`,
+      `👋 <b>Junto</b>\n\nTo link your account, open any newsletter on <a href="https://www.myjunto.xyz">myjunto.xyz</a>, hit <i>Subscribe</i>, switch to Telegram delivery, and copy the <code>/start</code> command into this chat.`,
     );
     return NextResponse.json({ ok: true });
   }

--- a/src/app/newsletter/[id]/page.tsx
+++ b/src/app/newsletter/[id]/page.tsx
@@ -58,7 +58,10 @@ export default function NewsletterDetailPage() {
   const [subDeliveryChannel, setSubDeliveryChannel] = useState<'email' | 'telegram'>('email');
   const [tgLinked, setTgLinked] = useState<boolean | null>(null);
   const [tgDeeplink, setTgDeeplink] = useState<string | null>(null);
+  const [tgCode, setTgCode] = useState<string | null>(null);
+  const [tgBotUsername, setTgBotUsername] = useState<string | null>(null);
   const [tgLinkingPoll, setTgLinkingPoll] = useState(false);
+  const [tgCopied, setTgCopied] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -118,14 +121,16 @@ export default function NewsletterDetailPage() {
     if (!res.ok) return;
     const data = await res.json();
     setTgDeeplink(data.deeplink);
-    window.open(data.deeplink, '_blank', 'noopener,noreferrer');
+    setTgCode(data.code);
+    setTgBotUsername(data.botUsername);
 
-    // Poll link status every 2s for up to 2 min — user DMs the bot, webhook
-    // captures chat_id, we flip tgLinked to true once it lands.
+    // Poll link status every 2s for up to 10 min — user DMs the bot, webhook
+    // captures chat_id, we flip tgLinked to true once it lands. Longer window
+    // since manual entry takes longer than a tap-through.
     setTgLinkingPoll(true);
     const start = Date.now();
     const interval = setInterval(async () => {
-      if (Date.now() - start > 120_000) {
+      if (Date.now() - start > 600_000) {
         clearInterval(interval);
         setTgLinkingPoll(false);
         return;
@@ -138,11 +143,23 @@ export default function NewsletterDetailPage() {
             setTgLinked(true);
             setTgLinkingPoll(false);
             setTgDeeplink(null);
+            setTgCode(null);
+            setTgBotUsername(null);
             clearInterval(interval);
           }
         }
       } catch {}
     }, 2000);
+  }
+
+  async function copyLinkCommand() {
+    if (!tgCode) return;
+    const cmd = `/start ${tgCode}`;
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setTgCopied(true);
+      setTimeout(() => setTgCopied(false), 2000);
+    } catch {}
   }
 
   async function toggleSubscription() {
@@ -482,26 +499,52 @@ export default function NewsletterDetailPage() {
                   <div className="px-3 py-2.5 bg-emerald-500/10 border border-emerald-500/30 rounded-xl text-sm text-emerald-300">
                     ✓ Connected — newsletters will arrive as DMs
                   </div>
+                ) : tgCode && tgBotUsername ? (
+                  <div className="space-y-3">
+                    <div className="text-xs text-slate-400 leading-relaxed">
+                      In Telegram, open a chat with{' '}
+                      <span className="text-white font-mono">@{tgBotUsername}</span>{' '}
+                      and send this message:
+                    </div>
+
+                    <button
+                      onClick={copyLinkCommand}
+                      className="w-full px-3 py-3 bg-slate-950 border border-slate-700 hover:border-blue-500 rounded-xl text-left transition group"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <code className="text-sm text-blue-300 font-mono">/start {tgCode}</code>
+                        <span className={`text-xs ${tgCopied ? 'text-emerald-400' : 'text-slate-500 group-hover:text-slate-300'} transition`}>
+                          {tgCopied ? '✓ copied' : 'tap to copy'}
+                        </span>
+                      </div>
+                    </button>
+
+                    {tgDeeplink && (
+                      <a
+                        href={tgDeeplink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block text-xs text-slate-400 hover:text-blue-300 text-center transition"
+                      >
+                        Or try auto-opening Telegram →
+                      </a>
+                    )}
+
+                    <div className="flex items-center gap-2 text-xs text-slate-500">
+                      <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
+                      {tgLinkingPoll ? 'Waiting for you to send the message…' : 'Checking link status…'}
+                    </div>
+                  </div>
                 ) : (
                   <div className="space-y-2">
                     <button
                       onClick={startTelegramLink}
                       className="w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 hover:border-blue-500 rounded-xl text-sm text-white transition"
                     >
-                      {tgLinkingPoll ? 'Waiting for you to message the bot…' : 'Link Telegram'}
+                      Link Telegram
                     </button>
-                    {tgDeeplink && (
-                      <a
-                        href={tgDeeplink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="block text-xs text-blue-400 hover:text-blue-300 text-center"
-                      >
-                        Open Telegram →
-                      </a>
-                    )}
                     <p className="text-xs text-slate-500">
-                      Opens Telegram and starts a chat with our bot. One tap to link.
+                      Generates a one-time code to DM our bot.
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

t.me deeplinks are unreliable across browsers/platforms. The existing linking UI depended on the deeplink working and gave users no fallback path when it didn't. This PR makes the code + command fully visible with a copy-to-clipboard button, so anyone can open Telegram manually, DM the bot, and paste the command.

## Changes

- **Modal UI**: shows bot `@username` and the full `/start ABC12345` command as a copy-able block. Deeplink still present but downgraded to a secondary "Or try auto-opening Telegram →" link.
- **Link API**: now returns `botUsername` so the UI doesn't need to know it separately.
- **Status polling**: extended from 2 min → 10 min since manual entry is slower than a tap-through.
- **Webhook `/start` reply**: updated to describe the new flow (was referencing `/settings` which doesn't have a Link button).

## Test plan

- [ ] Deploy
- [ ] Open newsletter subscribe modal → flip to Telegram → click "Link Telegram"
- [ ] Verify the bot username and `/start <code>` command are both visible
- [ ] Tap "tap to copy" → confirm clipboard contains `/start <code>`
- [ ] Open Telegram manually, paste into the bot chat, send
- [ ] Bot replies "✅ Linked" and modal flips to "✓ Connected" within 2s
- [ ] Test on a browser where t.me deeplinks don't work — confirm flow completes without ever using the deeplink