### PR TITLE
feat: move telegram linking to settings page

### DIFF
--- a/src/app/newsletter/[id]/page.tsx
+++ b/src/app/newsletter/[id]/page.tsx
@@ -57,11 +57,6 @@ export default function NewsletterDetailPage() {
   const [subDays, setSubDays] = useState<string[]>(['mon', 'tue', 'wed', 'thu', 'fri']);
   const [subDeliveryChannel, setSubDeliveryChannel] = useState<'email' | 'telegram'>('email');
   const [tgLinked, setTgLinked] = useState<boolean | null>(null);
-  const [tgDeeplink, setTgDeeplink] = useState<string | null>(null);
-  const [tgCode, setTgCode] = useState<string | null>(null);
-  const [tgBotUsername, setTgBotUsername] = useState<string | null>(null);
-  const [tgLinkingPoll, setTgLinkingPoll] = useState(false);
-  const [tgCopied, setTgCopied] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -116,49 +111,15 @@ export default function NewsletterDetailPage() {
     }
   }, [session]);
 
-  async function startTelegramLink() {
-    const res = await fetch('/api/telegram/link', { method: 'POST' });
-    if (!res.ok) return;
-    const data = await res.json();
-    setTgDeeplink(data.deeplink);
-    setTgCode(data.code);
-    setTgBotUsername(data.botUsername);
-
-    // Poll link status every 2s for up to 10 min — user DMs the bot, webhook
-    // captures chat_id, we flip tgLinked to true once it lands. Longer window
-    // since manual entry takes longer than a tap-through.
-    setTgLinkingPoll(true);
-    const start = Date.now();
-    const interval = setInterval(async () => {
-      if (Date.now() - start > 600_000) {
-        clearInterval(interval);
-        setTgLinkingPoll(false);
-        return;
-      }
-      try {
-        const r = await fetch('/api/telegram/link');
-        if (r.ok) {
-          const d = await r.json();
-          if (d.linked) {
-            setTgLinked(true);
-            setTgLinkingPoll(false);
-            setTgDeeplink(null);
-            setTgCode(null);
-            setTgBotUsername(null);
-            clearInterval(interval);
-          }
-        }
-      } catch {}
-    }, 2000);
-  }
-
-  async function copyLinkCommand() {
-    if (!tgCode) return;
-    const cmd = `/start ${tgCode}`;
+  // Refresh telegram link status when the subscribe modal opens, in case the
+  // user just linked in another tab (settings page).
+  async function refreshTelegramStatus() {
     try {
-      await navigator.clipboard.writeText(cmd);
-      setTgCopied(true);
-      setTimeout(() => setTgCopied(false), 2000);
+      const r = await fetch('/api/telegram/link');
+      if (r.ok) {
+        const d = await r.json();
+        setTgLinked(!!d.linked);
+      }
     } catch {}
   }
 
@@ -491,7 +452,7 @@ export default function NewsletterDetailPage() {
               </div>
             )}
 
-            {/* Telegram linking — shown when telegram channel is selected */}
+            {/* Telegram status — shown when telegram channel is selected */}
             {subDeliveryChannel === 'telegram' && (
               <div>
                 <label className="block text-xs text-slate-400 font-medium mb-2">Telegram</label>
@@ -499,53 +460,25 @@ export default function NewsletterDetailPage() {
                   <div className="px-3 py-2.5 bg-emerald-500/10 border border-emerald-500/30 rounded-xl text-sm text-emerald-300">
                     ✓ Connected — newsletters will arrive as DMs
                   </div>
-                ) : tgCode && tgBotUsername ? (
-                  <div className="space-y-3">
-                    <div className="text-xs text-slate-400 leading-relaxed">
-                      In Telegram, open a chat with{' '}
-                      <span className="text-white font-mono">@{tgBotUsername}</span>{' '}
-                      and send this message:
-                    </div>
-
-                    <button
-                      onClick={copyLinkCommand}
-                      className="w-full px-3 py-3 bg-slate-950 border border-slate-700 hover:border-blue-500 rounded-xl text-left transition group"
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <code className="text-sm text-blue-300 font-mono">/start {tgCode}</code>
-                        <span className={`text-xs ${tgCopied ? 'text-emerald-400' : 'text-slate-500 group-hover:text-slate-300'} transition`}>
-                          {tgCopied ? '✓ copied' : 'tap to copy'}
-                        </span>
-                      </div>
-                    </button>
-
-                    {tgDeeplink && (
-                      <a
-                        href={tgDeeplink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="block text-xs text-slate-400 hover:text-blue-300 text-center transition"
-                      >
-                        Or try auto-opening Telegram →
-                      </a>
-                    )}
-
-                    <div className="flex items-center gap-2 text-xs text-slate-500">
-                      <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
-                      {tgLinkingPoll ? 'Waiting for you to send the message…' : 'Checking link status…'}
-                    </div>
-                  </div>
                 ) : (
                   <div className="space-y-2">
-                    <button
-                      onClick={startTelegramLink}
-                      className="w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 hover:border-blue-500 rounded-xl text-sm text-white transition"
+                    <Link
+                      href="/settings"
+                      className="block w-full px-3 py-2.5 bg-slate-800/60 border border-slate-700 hover:border-blue-500 rounded-xl text-sm text-white transition text-center"
                     >
-                      Link Telegram
-                    </button>
-                    <p className="text-xs text-slate-500">
-                      Generates a one-time code to DM our bot.
-                    </p>
+                      Link Telegram in Settings →
+                    </Link>
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs text-slate-500">
+                        One-time setup. Applies to all your newsletters.
+                      </p>
+                      <button
+                        onClick={refreshTelegramStatus}
+                        className="text-xs text-slate-500 hover:text-blue-300 transition"
+                      >
+                        Already linked? Refresh
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -35,13 +35,94 @@ export default function SettingsPage() {
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
 
+  // Telegram linking
+  const [tgLinked, setTgLinked] = useState<boolean | null>(null);
+  const [tgCode, setTgCode] = useState<string | null>(null);
+  const [tgBotUsername, setTgBotUsername] = useState<string | null>(null);
+  const [tgPolling, setTgPolling] = useState(false);
+  const [tgCopied, setTgCopied] = useState(false);
+  const [tgUnlinking, setTgUnlinking] = useState(false);
+
   useEffect(() => {
     if (status === 'unauthenticated') router.push('/login');
   }, [status, router]);
 
   useEffect(() => {
-    if (session?.user) fetchAccount();
+    if (session?.user) {
+      fetchAccount();
+      fetchTelegramStatus();
+    }
   }, [session]);
+
+  const fetchTelegramStatus = async () => {
+    try {
+      const res = await fetch('/api/telegram/link');
+      if (res.ok) {
+        const data = await res.json();
+        setTgLinked(!!data.linked);
+      }
+    } catch {
+      setTgLinked(false);
+    }
+  };
+
+  const startTelegramLink = async () => {
+    const res = await fetch('/api/telegram/link', { method: 'POST' });
+    if (!res.ok) {
+      setError('Failed to generate link code. Try again.');
+      return;
+    }
+    const data = await res.json();
+    setTgCode(data.code);
+    setTgBotUsername(data.botUsername);
+
+    setTgPolling(true);
+    const start = Date.now();
+    const interval = setInterval(async () => {
+      if (Date.now() - start > 600_000) {
+        clearInterval(interval);
+        setTgPolling(false);
+        return;
+      }
+      try {
+        const r = await fetch('/api/telegram/link');
+        if (r.ok) {
+          const d = await r.json();
+          if (d.linked) {
+            setTgLinked(true);
+            setTgPolling(false);
+            setTgCode(null);
+            setTgBotUsername(null);
+            clearInterval(interval);
+          }
+        }
+      } catch {}
+    }, 2000);
+  };
+
+  const copyTelegramCommand = async () => {
+    if (!tgCode) return;
+    try {
+      await navigator.clipboard.writeText(`/start ${tgCode}`);
+      setTgCopied(true);
+      setTimeout(() => setTgCopied(false), 2000);
+    } catch {}
+  };
+
+  const unlinkTelegram = async () => {
+    if (!confirm('Unlink Telegram? Existing Telegram subscriptions will stop delivering until you re-link.')) return;
+    setTgUnlinking(true);
+    try {
+      const res = await fetch('/api/telegram/link', { method: 'DELETE' });
+      if (res.ok) {
+        setTgLinked(false);
+        setTgCode(null);
+        setTgBotUsername(null);
+      }
+    } finally {
+      setTgUnlinking(false);
+    }
+  };
 
   const fetchAccount = async () => {
     try {
@@ -194,6 +275,72 @@ export default function SettingsPage() {
           >
             {saving ? 'Saving...' : 'Save Settings'}
           </button>
+        </div>
+
+        {/* Telegram Section */}
+        <div className="mb-8 p-6 bg-slate-800/30 rounded-2xl border border-slate-700/40 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold">Telegram</h2>
+            <p className="text-sm text-slate-400 mt-1">
+              Link your Telegram to receive newsletters as DMs instead of email.
+            </p>
+          </div>
+
+          {tgLinked === null ? (
+            <div className="text-sm text-slate-500">Loading…</div>
+          ) : tgLinked ? (
+            <div className="flex items-center justify-between gap-3 p-3 bg-emerald-500/10 border border-emerald-500/30 rounded-xl">
+              <div className="text-sm text-emerald-300">
+                ✓ Connected — newsletters set to Telegram delivery will arrive as DMs.
+              </div>
+              <button
+                onClick={unlinkTelegram}
+                disabled={tgUnlinking}
+                className="px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-300 text-xs font-medium rounded-lg transition whitespace-nowrap disabled:opacity-50"
+              >
+                {tgUnlinking ? 'Unlinking…' : 'Unlink'}
+              </button>
+            </div>
+          ) : tgCode && tgBotUsername ? (
+            <div className="space-y-3">
+              <div className="text-sm text-slate-300 leading-relaxed">
+                In Telegram, open a chat with{' '}
+                <a
+                  href={`https://t.me/${tgBotUsername}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 hover:text-blue-300 font-mono"
+                >
+                  @{tgBotUsername}
+                </a>{' '}
+                and send this message:
+              </div>
+
+              <button
+                onClick={copyTelegramCommand}
+                className="w-full px-4 py-3 bg-slate-950 border border-slate-700 hover:border-blue-500 rounded-xl text-left transition group"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <code className="text-sm text-blue-300 font-mono">/start {tgCode}</code>
+                  <span className={`text-xs ${tgCopied ? 'text-emerald-400' : 'text-slate-500 group-hover:text-slate-300'} transition`}>
+                    {tgCopied ? '✓ copied' : 'tap to copy'}
+                  </span>
+                </div>
+              </button>
+
+              <div className="flex items-center gap-2 text-xs text-slate-500">
+                <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
+                {tgPolling ? 'Waiting for you to send the message…' : 'Checking link status…'}
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={startTelegramLink}
+              className="px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white rounded-xl text-sm font-medium transition"
+            >
+              Link Telegram
+            </button>
+          )}
         </div>
 
         {/* Provider Info */}


### PR DESCRIPTION
## Summary

`telegram_chat_id` is per-user, so all TG-delivery subscriptions flow to the same DM. Linking in the subscribe modal was confusing — looked like it was setting up TG for that newsletter only. Moving the link flow to `/settings` puts account-level config where account-level config belongs.

## Changes

**Settings page (`/settings`)** — new Telegram section:
- Shows current link status
- "Link Telegram" button generates a code, renders `/start XXX` with copy button
- Polls every 2s for up to 10 min
- "Unlink" button (with confirm) when already connected

**Subscribe modal (`/newsletter/[id]`)** — simplified:
- Telegram still available as a delivery channel
- When user isn't linked, shows "Link Telegram in Settings →" CTA linking to `/settings`
- "Already linked? Refresh" button for users who just linked in another tab
- Subscribe button disabled when TG selected but not linked
- Drops ~80 lines of inline link flow duplication

## Test plan

- [ ] Deploy
- [ ] Visit `/settings` → confirm Telegram section renders with "Link Telegram" button (when not linked)
- [ ] Click Link → verify bot username and `/start <code>` block appear
- [ ] Tap to copy → paste in TG → bot replies "✓ Linked" → settings flips to "✓ Connected" within 2s
- [ ] Hit Unlink → confirm → settings returns to "Link Telegram" state
- [ ] Re-link
- [ ] Open a newsletter subscribe modal → flip to Telegram → should immediately show "✓ Connected"
- [ ] Unlink in another tab, return to subscribe modal, click "Already linked? Refresh" → flips to "Link Telegram in Settings →"