### PR TITLE
feat: add ?force=true bypass on generate-newsletters for manual testing

### DIFF
--- a/src/app/api/cron/generate-newsletters/route.ts
+++ b/src/app/api/cron/generate-newsletters/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getNewslettersDueForGeneration, getNewsletterSources, getCurrentSendWindow, getCurrentPSTDay } from '@/lib/db/newsletters-v2';
+import { getNewslettersDueForGeneration, getNewslettersForForcedGeneration, getNewsletterSources, getCurrentSendWindow, getCurrentPSTDay } from '@/lib/db/newsletters-v2';
 import { getRecentContentForSources, getContextContentForSources, groupContentByHandle } from '@/lib/db/content-twitter';
 import { getNewsletterSubscribers } from '@/lib/db/subscriptions';
 import { storeRun } from '@/lib/db/newsletter-runs';
@@ -24,13 +24,27 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const dueNewsletters = await getNewslettersDueForGeneration();
+    // Manual-testing escape hatch: ?force=true bypasses the time-of-day/day
+    // gate. Still requires active subscribers. Optional newsletter_id scopes
+    // to one newsletter. Auth header is already verified above.
+    const url = new URL(req.url);
+    const force = url.searchParams.get('force') === 'true';
+    const forceNewsletterId = url.searchParams.get('newsletter_id') || undefined;
+
+    const dueNewsletters = force
+      ? await getNewslettersForForcedGeneration(forceNewsletterId)
+      : await getNewslettersDueForGeneration();
 
     if (dueNewsletters.length === 0) {
-      return NextResponse.json({ success: true, message: 'No newsletters due', generated: 0 });
+      return NextResponse.json({
+        success: true,
+        message: force ? 'No newsletters with active subscribers' : 'No newsletters due',
+        generated: 0,
+        forced: force,
+      });
     }
 
-    console.log(`[generate] ${dueNewsletters.length} newsletter(s) due for generation`);
+    console.log(`[generate] ${dueNewsletters.length} newsletter(s) ${force ? 'forced' : 'due'} for generation`);
 
     const results: Record<string, { status: string; subscribers?: number; error?: string }> = {};
 
@@ -120,17 +134,20 @@ export async function GET(req: NextRequest) {
           continue;
         }
 
-        // 7. Fan out to subscribers — charge each, send email
-        // Filter to subscribers who want this window AND this day
+        // 7. Fan out to subscribers — charge each, send
+        // Normally filter to subscribers who want this window AND this day.
+        // When force=true, send to every active subscriber regardless.
         const allSubscribers = await getNewsletterSubscribers(newsletter.id);
         const currentWindow = getCurrentSendWindow();
         const currentDay = getCurrentPSTDay();
-        const subscribers = allSubscribers.filter(sub => {
-          const windows = sub.receive_windows || sub.send_windows || ['morning'];
-          const days = sub.receive_days || ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-          return (!currentWindow || windows.includes(currentWindow)) &&
-                 (!currentDay || days.includes(currentDay));
-        });
+        const subscribers = force
+          ? allSubscribers
+          : allSubscribers.filter(sub => {
+              const windows = sub.receive_windows || sub.send_windows || ['morning'];
+              const days = sub.receive_days || ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+              return (!currentWindow || windows.includes(currentWindow)) &&
+                     (!currentDay || days.includes(currentDay));
+            });
 
         if (subscribers.length === 0) {
           console.log(`[generate] No subscribers for ${newsletter.name}`);

--- a/src/lib/db/newsletters-v2.ts
+++ b/src/lib/db/newsletters-v2.ts
@@ -414,3 +414,34 @@ export async function getNewslettersDueForGeneration(): Promise<NewsletterV2[]> 
 
   return due;
 }
+
+// Bypass the time-of-day/day-of-week gate for manual testing. Still requires
+// at least one active subscriber. If newsletterId is provided, only that one
+// is returned (if it has subscribers).
+export async function getNewslettersForForcedGeneration(
+  newsletterId?: string,
+): Promise<NewsletterV2[]> {
+  const { data: subData, error: subError } = await supabase()
+    .from('subscriptions')
+    .select('newsletter_id')
+    .eq('is_active', true);
+
+  if (subError || !subData?.length) return [];
+
+  const subscribedIds = new Set<string>(subData.map((s) => s.newsletter_id));
+  if (subscribedIds.size === 0) return [];
+
+  const ids = newsletterId
+    ? [newsletterId].filter((id) => subscribedIds.has(id))
+    : Array.from(subscribedIds);
+
+  if (ids.length === 0) return [];
+
+  const { data: newsletters, error } = await supabase()
+    .from('newsletters_v2')
+    .select('*')
+    .in('id', ids);
+
+  if (error) return [];
+  return newsletters || [];
+}


### PR DESCRIPTION
## Summary

The time-of-day gate on `generate-newsletters` (window check fires only within 15 min of 6 AM / 12 PM / 6 PM / 12 AM Pacific) means manual curl triggers outside those windows silently return "No newsletters due" and no-op. Painful for debugging TG delivery.

Adds `?force=true` bypass so the endpoint fires on demand, and `?newsletter_id=<uuid>` to scope to one newsletter.

## Changes

- New helper `getNewslettersForForcedGeneration()`: returns newsletters with any active subscriber, optionally scoped to one newsletter_id. Skips window/day/5h-gap filters.
- Route accepts `?force=true` and `?newsletter_id=<uuid>`. Auth still required (`CRON_SECRET` Bearer header).
- When forced, subscriber window/day filter also skipped (every active subscriber gets it) — intent is "fire now for testing."

## Usage

```bash
# All newsletters with active subscribers
curl -H 'Authorization: Bearer $CRON_SECRET' \
  'https://www.myjunto.xyz/api/cron/generate-newsletters?force=true' | jq .

# Scope to one newsletter
curl -H 'Authorization: Bearer $CRON_SECRET' \
  'https://www.myjunto.xyz/api/cron/generate-newsletters?force=true&newsletter_id=abc-123' | jq .
```

Force still charges credits, stores a `newsletter_run`, and delivers via each subscriber's configured channel (email or telegram). It's a real generation, just outside the normal schedule.

## Test plan

- [ ] Deploy
- [ ] `curl ?force=true` → should see `generated: N` in response where N matches number of newsletters with active subs
- [ ] `newsletter_runs` table has new rows
- [ ] Email subscribers get email
- [ ] TG subscribers get DM in their chat
- [ ] `newsletter_deliveries` has rows with `delivery_method` matching each subscriber's channel

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tmi72w7udKChd9jtrywkRU)_